### PR TITLE
renamed Ukrainian translation according to ISO 639-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For online reading navigate to:
 * Turkish: https://raku.guide/tr
 * Indonesian: https://raku.guide/id
 * Russian: https://raku.guide/ru
-* Ukrainian: https://raku.guide/ua
+* Ukrainian: https://raku.guide/uk
 
 ### Building the document
 The document is written in asciidoc format and generated using

--- a/bg.rakuguide.adoc
+++ b/bg.rakuguide.adoc
@@ -48,14 +48,15 @@ link:https://github.com/hankache/perl6intro[Github].
 
 .Преводи
 
-* Български: http://bg.perl6intro.com
-* Испански: http://es.perl6intro.com
-* Китайски: http://zh.perl6intro.com
-* Немски: http://de.perl6intro.com
-* Португалски: http://pt.perl6intro.com
-* Френски: http://fr.perl6intro.com
-* Холандски: http://nl.perl6intro.com
-* Японски: http://ja.perl6intro.com
+* Български: https://raku.guide/bg
+* Испански: https://raku.guide/es
+* Китайски: https://raku.guide/zh
+* Немски: https://raku.guide/de
+* Португалски: https://raku.guide/pt
+* Френски: https://raku.guide/fr
+* Холандски: https://raku.guide/nl
+* Японски: https://raku.guide/ja
+* Украински: https://raku.guide/uk
 
 :sectnums:
 == Увод

--- a/it.rakuguide.adoc
+++ b/it.rakuguide.adoc
@@ -45,15 +45,16 @@ link:https://github.com/hankache/perl6intro[Github]
 grazie!
 
 .Altre versioni disponibili
-* Bulgaro: http://bg.perl6intro.com
-* Cinese: http://zh.perl6intro.com
-* Francese: http://fr.perl6intro.com
-* Giapponese: http://ja.perl6intro.com
-* Inglese: http://perl6intro.com
-* Olandese: http://nl.perl6intro.com
-* Portoghese: http://pt.perl6intro.com
-* Spagnolo: http://es.perl6intro.com
-* Tedesco: http://de.perl6intro.com
+* Bulgaro: https://raku.guide/bg
+* Cinese: https://raku.guide/zh
+* Francese: https://raku.guide/fr
+* Giapponese: https://raku.guide/ja
+* Inglese: https://raku.guide
+* Olandese: https://raku.guide/nl
+* Portoghese: https://raku.guide/pt
+* Spagnolo: https://raku.guide/es
+* Tedesco: https://raku.guide/de
+* Ucraniano: https://raku.guide/uk
 
 
 :sectnums:

--- a/pt.rakuguide.adoc
+++ b/pt.rakuguide.adoc
@@ -55,6 +55,7 @@ Se você gostou desse trabalho, clique na _estrela_ do repositório no link:http
 * Português: https://raku.guide/pt
 * Russo: https://raku.guide/ru
 * Turco: https://raku.guide/tr
+* Ucraniano: https://raku.guide/uk
 
 :sectnums:
 == Introdução

--- a/rakuguide.adoc
+++ b/rakuguide.adoc
@@ -54,7 +54,7 @@ link:https://github.com/hankache/rakuguide[Github].
 * Spanish: https://raku.guide/es
 * Turkish: https://raku.guide/tr
 * Russian: https://raku.guide/ru
-* Ukrainian: https://raku.guide/ua
+* Ukrainian: https://raku.guide/uk
 
 :sectnums:
 == Introduction

--- a/ru.rakuguide.adoc
+++ b/ru.rakuguide.adoc
@@ -56,6 +56,7 @@ link:https://github.com/hankache/rakuguide[Github].
 * Испанский: https://raku.guide/es
 * Турецкий: https://raku.guide/tr
 * Русский: https://raku.guide/ru
+* Украинский: https://raku.guide/uk
 
 :sectnums:
 == Введение

--- a/tr.rakuguide.adoc
+++ b/tr.rakuguide.adoc
@@ -43,16 +43,17 @@ Bu eseri beğendiyseniz, kaynağına göz atabilirsiniz
 link:https://github.com/hankache/perl6intro[Github].
 
 .Çeviriler
-* Almanca: http://de.perl6intro.com
-* Bulgarca: http://bg.perl6intro.com
-* Çince: http://zh.perl6intro.com
-* Flemenkçe: http://nl.perl6intro.com
-* Fransızca: http://fr.perl6intro.com
-* İngilizce: http://perl6intro.com
-* İspanyolca: http://es.perl6intro.com
-* İtalyanca: http://it.perl6intro.com
-* Japonca: http://ja.perl6intro.com
-* Portekizce: http://pt.perl6intro.com
+* Almanca: https://raku.guide/de
+* Bulgarca: https://raku.guide/bg
+* Çince: https://raku.guide/zh
+* Flemenkçe: https://raku.guide/nl
+* Fransızca: https://raku.guide/fr
+* İngilizce: https://raku.guide
+* İspanyolca: https://raku.guide/es
+* İtalyanca: https://raku.guide/it
+* Japonca: https://raku.guide/ja
+* Portekizce: https://raku.guide/pt
+* Ukraynaca: https://raku.guide/uk
 
 :sectnums:
 == Giriş

--- a/uk.rakuguide.adoc
+++ b/uk.rakuguide.adoc
@@ -53,7 +53,7 @@ Naoum Hankache <naoum@hankache.com>; Dmytro Iaskolko <mescalito.ua@gmail.com>;
 * Португальський: https://raku.guide/pt
 * Іспаньский: https://raku.guide/es
 * Турецький: https://raku.guide/tr
-* Украінський: https://raku.guide/ua
+* Украінський: https://raku.guide/uk
 
 :sectnums:
 

--- a/zh.rakuguide.adoc
+++ b/zh.rakuguide.adoc
@@ -52,6 +52,7 @@ link:https://github.com/hankache/rakuguide[Github] 给这个仓库点赞。
 * 西班牙语: https://raku.guide/es
 * 土耳其语: https://raku.guide/tr
 * 俄语: https://raku.guide/ru
+* 烏克蘭: https://raku.guide/uk
 
 :sectnums:
 == 序言


### PR DESCRIPTION
This is a minor change.
* renamed Ukrainian translation to comply with  ISO 639-1
* updated lists of translations where applicable.